### PR TITLE
handle exceptions during reserved balances recalculation

### DIFF
--- a/src/main/kotlin/com/lykke/matching/engine/utils/balance/ReservedVolumesRecalculator.kt
+++ b/src/main/kotlin/com/lykke/matching/engine/utils/balance/ReservedVolumesRecalculator.kt
@@ -63,23 +63,28 @@ class ReservedVolumesRecalculator(private val walletDatabaseAccessor: WalletData
         var count = 1
         orders.forEach { order ->
             if (!trustedClients.contains(order.clientId)) {
-                LOGGER.info("${count++} Client:${order.clientId}, id: ${order.externalId}, asset:${order.assetPairId}, price:${order.price}, volume:${order.volume}, date:${order.registered}, status:${order.status}, reserved: ${order.reservedLimitVolume}}")
-                val assetPair = assetsPairsHolder.getAssetPair(order.assetPairId)
-                val asset = assetsHolder.getAsset(if (order.isBuySide()) assetPair.quotingAssetId else assetPair.baseAssetId)
+                try {
+                    LOGGER.info("${count++} Client:${order.clientId}, id: ${order.externalId}, asset:${order.assetPairId}, price:${order.price}, volume:${order.volume}, date:${order.registered}, status:${order.status}, reserved: ${order.reservedLimitVolume}}")
+                    val assetPair = assetsPairsHolder.getAssetPair(order.assetPairId)
+                    val asset = assetsHolder.getAsset(if (order.isBuySide()) assetPair.quotingAssetId else assetPair.baseAssetId)
 
-                val reservedVolume = if (order.reservedLimitVolume != null) {
-                    order.reservedLimitVolume!!
-                } else {
-                    val calculatedReservedVolume = if (order.isBuySide()) RoundingUtils.round(order.getAbsRemainingVolume() * order.price , asset.accuracy, false) else order.getAbsRemainingVolume()
-                    LOGGER.info("Null reserved volume, recalculated: $calculatedReservedVolume")
-                    calculatedReservedVolume
+                    val reservedVolume = if (order.reservedLimitVolume != null) {
+                        order.reservedLimitVolume!!
+                    } else {
+                        val calculatedReservedVolume = if (order.isBuySide()) RoundingUtils.round(order.getAbsRemainingVolume() * order.price, asset.accuracy, false) else order.getAbsRemainingVolume()
+                        LOGGER.info("Null reserved volume, recalculated: $calculatedReservedVolume")
+                        calculatedReservedVolume
+                    }
+
+                    val clientAssets = reservedBalances.getOrPut(order.clientId) { HashMap() }
+                    val balance = clientAssets.getOrPut(asset.assetId) { ClientOrdersReservedVolume() }
+                    val newBalance = RoundingUtils.parseDouble(balance.volume + reservedVolume, asset.accuracy).toDouble()
+                    balance.volume = newBalance
+                    balance.orderIds.add(order.externalId)
+                } catch (e: Exception) {
+                    val errorMessage = "Unable to handle order (id: ${order.externalId}): ${e.message}"
+                    teeLog(errorMessage)
                 }
-
-                val clientAssets = reservedBalances.getOrPut(order.clientId) { HashMap() }
-                val balance = clientAssets.getOrPut(asset.assetId) { ClientOrdersReservedVolume() }
-                val newBalance = RoundingUtils.parseDouble(balance.volume + reservedVolume, asset.accuracy).toDouble()
-                balance.volume = newBalance
-                balance.orderIds.add(order.externalId)
             }
         }
         LOGGER.info("---------------------------------------------------------------------------------------------------")


### PR DESCRIPTION
There was case on dev:
one of assets of LO asset pair is missing in dictionary => exception during reserved balances recalculation => app is not started