### PR TITLE
LWDEV-10406 One thread for all throttling loggers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ repositories {
 }
 
 ext {
-    kotlin_utils_version = '0.0.8-SNAPSHOT'
+    kotlin_utils_version = '0.0.9-SNAPSHOT'
     log4j_version = '1.2.17'
     protobuf_version = '3.6.0'
     azure_storage_version = '4.0.0'


### PR DESCRIPTION
Currently each ThrottlingLogger instance creates a separate thread to clear their logged errors cache.
Changed kotlin-utils lib - added single thread with one common logged errors cache for all loggers.